### PR TITLE
Update RuleBase.cs

### DIFF
--- a/HippoValidator.GooglePageSpeedClient/RuleBase.cs
+++ b/HippoValidator.GooglePageSpeedClient/RuleBase.cs
@@ -22,11 +22,11 @@ namespace HippoValidator.GooglePageSpeedClient
       }
     }
 
-    public int RuleImpact
+    public double RuleImpact
     {
       get
       {
-        return JsonClassHelper.ReadInteger(JsonClassHelper.GetJToken<JValue>(Jobject, "ruleImpact"));
+        return JsonClassHelper.ReadFloat(JsonClassHelper.GetJToken<JValue>(Jobject, "ruleImpact"));
       }
     }
 


### PR DESCRIPTION
RuleImpact is returned from Google as a double and not an int.